### PR TITLE
Upcast len bytes before performing arithmetic

### DIFF
--- a/osdp_packet.go
+++ b/osdp_packet.go
@@ -180,11 +180,12 @@ func NewPacketFromBytes(payload []byte) (*OSDPPacket, error) {
 
 	// Parse the message length
 	currentIndex++
-	var messageLength uint16 = uint16(payload[currentIndex] | (payload[currentIndex+1] << 8))
+	messageLength := uint16(payload[currentIndex]) + uint16(payload[currentIndex+1])<<8
 	bytesRemaining := messageLength - minimumPacketLengthUnsecure
 	if len(payload) < int(messageLength) {
 		return nil, PacketIncompleteError
 	}
+
 	// Check the message control info. TODO: Check for MAC
 	currentIndex += 2
 	msgControlInfo := payload[currentIndex]


### PR DESCRIPTION
The length field is a little endian 16-bit unsigned integer.  When unmarshalling the two bytes into a number, the operands must be cast to a wider integer type before performing addition and left-shift, otherwise the intermediate result overflows, yielding the wrong result.